### PR TITLE
Review c++ embedded code as senior

### DIFF
--- a/main/include/Task.hpp
+++ b/main/include/Task.hpp
@@ -16,11 +16,14 @@
 
 #pragma once
 
+#include <functional>
+#include "esp_err.h"
+
 namespace kopter {
 
 class Task {
 public:
-    using TaskFn = std::function<void()>;
+    using TaskFn = std::function<esp_err_t()>;
 
     Task(const char *task_name, uint32_t stack_size, TaskFn fn);
     Task(const char *task_name, uint32_t stack_size, UBaseType_t priority, TaskFn fn);


### PR DESCRIPTION
Refactor FreeRTOS task functions to return `esp_err_t` and handle exceptions.

This change improves task robustness by ensuring that all task functions explicitly return an error status and that any C++ exceptions are caught and logged at the task entry point. This prevents unhandled exceptions from propagating out of FreeRTOS task contexts, which could lead to `std::terminate` or undefined behavior, and provides clearer error reporting for critical background operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef93d369-d17b-4795-a18c-b55453f33373">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef93d369-d17b-4795-a18c-b55453f33373">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

